### PR TITLE
Enable Enter key to send messages

### DIFF
--- a/web/src/views/chat.rs
+++ b/web/src/views/chat.rs
@@ -40,9 +40,23 @@ pub fn Chat() -> Element {
                 }
             }
             div { id: "input-area",
-                input { 
+                input {
                     value: "{input}",
                     oninput: move |e| input.set(e.value()),
+                    onkeydown: move |e| async move {
+                        if e.key() == Key::Enter {
+                            let text = input().clone();
+                            let mut msgs = messages.clone();
+                            let mut input_signal = input.clone();
+                            if !text.is_empty() {
+                                api::send_message(text).await.ok();
+                                if let Ok(all) = api::get_messages().await {
+                                    msgs.set(all);
+                                }
+                                input_signal.set(String::new());
+                            }
+                        }
+                    },
                     placeholder: "Type a message...",
                 }
                 button { onclick: on_send, "Send" }


### PR DESCRIPTION
## Summary
- allow pressing Enter in the input box to send a chat message

## Testing
- `cargo check --workspace`
- `dx build --platform web` *(fails: command not found)*
- `dx build --platform desktop` *(fails: command not found)*
- `dx build --platform mobile` *(fails: command not found)*
- `dx serve --platform web` *(fails: command not found)*
- `dx serve --platform desktop` *(fails: command not found)*
- `dx serve --platform mobile` *(fails: command not found)*
- `dx fmt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684633618ac48323be7146b7952ae265