### PR TITLE
Improve chat UI layout and add settings route

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5233,6 +5233,7 @@ version = "0.1.0"
 dependencies = [
  "api",
  "dioxus",
+ "web-sys",
 ]
 
 [[package]]

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 dioxus = { workspace = true, features = ["router"] }
 api = { workspace = true }
+web-sys = { version = "0.3", features = ["Window", "MediaQueryList"] }
 
 [features]
 default = []

--- a/web/assets/tailwind.css
+++ b/web/assets/tailwind.css
@@ -1,10 +1,11 @@
 /*! tailwindcss v4.1.8 | MIT License | https://tailwindcss.com */
+@import url('https://fonts.googleapis.com/css2?family=Proxima+Vara:wght@100..900&display=swap');
 @layer properties;
 @layer theme, base, components, utilities;
 @layer theme {
   :root, :host {
-    --font-sans: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
-      "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    --font-sans: "Proxima Vara", ui-sans-serif, system-ui, sans-serif,
+      "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
     --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
       "Courier New", monospace;
     --color-gray-700: oklch(37.3% 0.034 259.733);

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -1,13 +1,15 @@
 use dioxus::prelude::*;
 
 mod views;
-use views::Chat;
+use views::{Chat, Settings};
 
 #[derive(Debug, Clone, Routable, PartialEq)]
 #[rustfmt::skip]
 enum Route {
     #[route("/")]
     Chat {},
+    #[route("/settings")]
+    Settings {},
 }
 
 const FAVICON: Asset = asset!("/assets/favicon.ico");
@@ -23,6 +25,7 @@ fn App() -> Element {
     rsx! {
         // Global app resources
         document::Link { rel: "icon", href: FAVICON }
+        document::Stylesheet { href: "https://fonts.googleapis.com/css2?family=Proxima+Vara:wght@100..900&display=swap" }
         document::Stylesheet {
             // Urls are relative to your Cargo.toml file
             href: asset!("/assets/tailwind.css"),

--- a/web/src/views/chat.rs
+++ b/web/src/views/chat.rs
@@ -1,4 +1,5 @@
 use dioxus::prelude::*;
+use crate::Route;
 
 #[component]
 pub fn Chat() -> Element {
@@ -8,7 +9,27 @@ pub fn Chat() -> Element {
     let mut input = use_signal(|| String::new());
     let mut search = use_signal(|| String::new());
     let mut model = use_signal(|| String::from("gpt-3.5"));
-    let mut dark = use_signal(|| false);
+    let mut theme = use_signal(|| String::from("system"));
+
+    let is_dark = move || {
+        match theme().as_str() {
+            "dark" => true,
+            "system" => {
+                #[cfg(feature = "web")]
+                {
+                    web_sys::window()
+                        .and_then(|w| w.match_media("(prefers-color-scheme: dark)").ok().flatten())
+                        .map(|m| m.matches())
+                        .unwrap_or(false)
+                }
+                #[cfg(not(feature = "web"))]
+                {
+                    false
+                }
+            }
+            _ => false,
+        }
+    };
 
     // Load available conversations on mount
     use_effect(move || {
@@ -67,94 +88,82 @@ pub fn Chat() -> Element {
         }
     };
 
-    let show_sidebar = !(messages().is_empty() && conversations().len() <= 1);
     let filtered: Vec<usize> = conversations()
         .into_iter()
-        .filter(|cid| cid.to_string().contains(&search()))
+        .filter(|cid| cid.to_string().to_lowercase().contains(&search().to_lowercase()))
         .collect();
 
-    let sidebar = if show_sidebar {
-        rsx! {
-            div { class: "w-48 border-r border-gray-700 p-2 flex flex-col",
-                input {
-                    r#type: "text",
-                    placeholder: "Search...",
-                    value: "{search}",
-                    oninput: move |e| search.set(e.value()),
-                }
-                button {
-                    onclick: move |_| {
-                        spawn(on_new_conv(()));
-                    },
-                    "New"
-                }
-                ul { class: "flex-1 overflow-y-auto list-none p-0",
-                    for cid in filtered.iter().cloned() {
-                        li {
-                            class: if Some(cid) == current() { "bg-gray-800 p-1" } else { "p-1" },
-                            onclick: move |_| current.set(Some(cid)),
-                            "Conversation {cid}"
-                        }
+    let sidebar = rsx! {
+        div { class: "w-48 border-r border-gray-700 p-2 flex flex-col h-full",
+            button {
+                class: "mb-2 p-1 bg-gray-700 text-white rounded",
+                onclick: move |_| {
+                    spawn(on_new_conv(()));
+                },
+                "New Chat"
+            }
+            input {
+                class: "mb-2 pb-1 border-b border-gray-300 bg-transparent outline-none",
+                r#type: "text",
+                placeholder: "Search...",
+                value: "{search}",
+                oninput: move |e| search.set(e.value()),
+            }
+            ul { class: "flex-1 overflow-y-auto list-none p-0",
+                for cid in filtered.iter().cloned() {
+                    li {
+                        class: if Some(cid) == current() { "bg-gray-800 p-1" } else { "p-1" },
+                        onclick: move |_| current.set(Some(cid)),
+                        "Conversation {cid}"
                     }
                 }
-                div { class: "account", "Logged in" }
             }
+            Link { to: Route::Settings {}, class: "mt-2 text-left text-sm", "Account" }
         }
-    } else {
-        rsx!(div {})
     };
 
     rsx! {
-        div { class: if dark() { "dark bg-gray-900 text-white flex flex-col h-screen" } else { "bg-white text-black flex flex-col h-screen" },
-            div { class: "flex justify-between items-center p-2 border-b border-gray-700",
-                div {
-                    select {
-                        value: "{model}",
-                        onchange: move |e| model.set(e.value()),
-                        option { value: "gpt-3.5", "GPT-3.5" }
-                        option { value: "gpt-4", "GPT-4" }
-                    }
-                }
-                div { class: "flex items-center gap-2",
-                    button { "Settings" }
-                    label {
-                        "Dark"
-                        input {
-                            r#type: "checkbox",
-                            checked: dark(),
-                            onchange: move |_| dark.set(!dark()),
-                        }
-                    }
-                }
-            }
-            div { class: "flex flex-1",
+        div { class: if is_dark() { "dark bg-gray-900 text-white flex flex-col h-screen font-sans p-4" } else { "bg-white text-black flex flex-col h-screen font-sans p-4" },
+            div { class: "flex flex-1 overflow-hidden",
                 {sidebar}
-                div { class: "flex flex-col flex-1",
-                    div { class: "flex-1 border border-gray-700 p-2 overflow-y-auto",
-                        for msg in messages().iter() {
-                            p { "{msg}" }
+                div { class: "flex flex-col flex-1 pl-4",
+                    div { class: if messages().is_empty() { "flex-1 border border-gray-700 p-2 overflow-y-auto flex items-center justify-center" } else { "flex-1 border border-gray-700 p-2 overflow-y-auto" },
+                        if !messages().is_empty() {
+                            for msg in messages().iter() {
+                                p { "{msg}" }
+                            }
                         }
                     }
-                    div { class: "flex gap-2 mt-auto",
-                        div { class: "flex gap-2 flex-1",
-                            input {
-                                class: "flex-1 p-1",
-                                value: "{input}",
-                                oninput: move |e| input.set(e.value()),
-                                onkeydown: move |e| {
-                                    if e.key() == Key::Enter {
-                                        spawn(on_send(()));
-                                    }
-                                },
-                                placeholder: "Type a message...",
-                            }
-                            button {
-                                class: "bg-gray-700 text-white rounded px-2",
-                                onclick: move |_| {
+                    div { class: if messages().is_empty() { "flex gap-2 mt-4" } else { "flex gap-2 mt-2" },
+                        input {
+                            class: "flex-1 p-1 border border-gray-700 rounded",
+                            value: "{input}",
+                            oninput: move |e| input.set(e.value()),
+                            onkeydown: move |e| {
+                                if e.key() == Key::Enter {
                                     spawn(on_send(()));
-                                },
-                                "Send"
-                            }
+                                }
+                            },
+                            placeholder: "Type a message...",
+                        }
+                        button {
+                            class: "bg-gray-700 text-white rounded px-2",
+                            onclick: move |_| {
+                                spawn(on_send(()));
+                            },
+                            "Send"
+                        }
+                        select {
+                            class: "border border-gray-700 rounded p-1",
+                            value: "{model}",
+                            onchange: move |e| model.set(e.value()),
+                            option { value: "gpt-3.5", "GPT-3.5" }
+                            option { value: "gpt-4", "GPT-4" }
+                        }
+                        Link {
+                            to: Route::Settings {},
+                            class: "underline text-sm",
+                            "Settings"
                         }
                     }
                 }

--- a/web/src/views/mod.rs
+++ b/web/src/views/mod.rs
@@ -1,2 +1,5 @@
 mod chat;
 pub use chat::Chat;
+
+mod settings;
+pub use settings::Settings;

--- a/web/src/views/settings.rs
+++ b/web/src/views/settings.rs
@@ -1,0 +1,21 @@
+use dioxus::prelude::*;
+use crate::Route;
+
+#[component]
+pub fn Settings() -> Element {
+    let mut theme = use_signal(|| String::from("system"));
+    rsx! {
+        div { class: "p-4 space-y-4",
+            h1 { class: "text-xl font-bold", "Settings" }
+            div {
+                label { class: "mr-2", "Theme:" }
+                select { value: "{theme}", onchange: move |e| theme.set(e.value()),
+                    option { value: "system", "System" }
+                    option { value: "light", "Light" }
+                    option { value: "dark", "Dark" }
+                }
+            }
+            Link { to: Route::Chat {}, class: "text-blue-500 underline", "Back" }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- embed Proxima Vara and use it as the main font
- add settings page and new route
- always display sidebar with new chat/search improvements
- center input box when no messages
- move model selector into chat box and add link to settings
- load fonts via stylesheet

## Testing
- `cargo check --workspace`
- `dx build --platform web`
- `dx build --platform desktop` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846869ed3988323ab103fb912f27aac