### PR TITLE
Add highlight.js and markdown rendering for chat messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1956,6 +1956,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cba6ae63eb948698e300f645f87c70f76630d505f23b8907cf1e193ee85048c1"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3705,6 +3714,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
+dependencies = [
+ "bitflags 2.9.1",
+ "getopts",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5018,6 +5039,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5233,6 +5260,8 @@ version = "0.1.0"
 dependencies = [
  "api",
  "dioxus",
+ "pulldown-cmark",
+ "wasm-bindgen",
  "web-sys",
 ]
 

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 dioxus = { workspace = true, features = ["router"] }
 api = { workspace = true }
 web-sys = { version = "0.3", features = ["Window", "MediaQueryList"] }
+pulldown-cmark = "0.9"
+wasm-bindgen = "0.2"
 
 [features]
 default = []

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -30,6 +30,8 @@ fn App() -> Element {
             // Urls are relative to your Cargo.toml file
             href: asset!("/assets/tailwind.css"),
         }
+        document::Stylesheet { href: "https://cdn.jsdelivr.net/npm/highlight.js@11.8.0/styles/github-dark.min.css" }
+        document::Script { src: "https://cdn.jsdelivr.net/npm/highlight.js@11.8.0/lib/common.min.js" }
 
         Router::<Route> {}
     }


### PR DESCRIPTION
## Summary
- support markdown and code block highlighting in chat
- load highlight.js assets in the web app
- render chat messages as markdown

## Testing
- `dx fmt --check`
- `cargo check --workspace --exclude mobile`

------
https://chatgpt.com/codex/tasks/task_e_6848647e64f883238ab067172205c85f