### PR TITLE
Implement basic authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,9 @@ dx build --package desktop
 ```bash
 npx @tailwindcss/cli -i ./input.css -o ./assets/tailwind.css --watch
 ```
+
+## Authentication
+
+The app now includes a very basic authentication flow. Navigate to `/login` to
+create an account and sign in. Credentials are stored in memory on the server
+for demonstration purposes only.

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -2,6 +2,7 @@
 use dioxus::prelude::*;
 use once_cell::sync::Lazy;
 use std::sync::Arc;
+use std::collections::HashMap;
 use tokio::sync::RwLock;
 
 /// Represents the messages for each conversation.
@@ -10,6 +11,10 @@ type Conversations = Vec<Vec<String>>;
 /// In memory list of chat messages.
 /// In memory list of conversations. Each conversation is a vector of chat messages.
 static CHAT_HISTORY: Lazy<Arc<RwLock<Conversations>>> = Lazy::new(|| Arc::new(RwLock::new(vec![Vec::new()])));
+
+/// In-memory store of users where the key is the username and the value is the password.
+static USERS: Lazy<Arc<RwLock<HashMap<String, String>>>> =
+    Lazy::new(|| Arc::new(RwLock::new(HashMap::new())));
 
 /// Echo the user input on the server.
 #[server(Echo)]
@@ -48,4 +53,22 @@ pub async fn send_message(conv_id: usize, msg: String) -> Result<(), ServerFnErr
 pub async fn get_messages(conv_id: usize) -> Result<Vec<String>, ServerFnError> {
     let history = CHAT_HISTORY.read().await;
     Ok(history.get(conv_id).cloned().unwrap_or_default())
+}
+
+/// Register a new user with a username and password.
+#[server(Register)]
+pub async fn register(username: String, password: String) -> Result<(), ServerFnError> {
+    let mut users = USERS.write().await;
+    if users.contains_key(&username) {
+        return Err(ServerFnError::new("User already exists"));
+    }
+    users.insert(username, password);
+    Ok(())
+}
+
+/// Verify user credentials and return true if they are valid.
+#[server(Login)]
+pub async fn login(username: String, password: String) -> Result<bool, ServerFnError> {
+    let users = USERS.read().await;
+    Ok(users.get(&username).map(|p| p == &password).unwrap_or(false))
 }

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -1,7 +1,7 @@
 use dioxus::prelude::*;
 
 mod views;
-use views::{Chat, Settings};
+use views::{Chat, Settings, Login};
 
 #[derive(Debug, Clone, Routable, PartialEq)]
 #[rustfmt::skip]
@@ -10,6 +10,8 @@ enum Route {
     Chat {},
     #[route("/settings")]
     Settings {},
+    #[route("/login")]
+    Login {},
 }
 
 const FAVICON: Asset = asset!("/assets/favicon.ico");

--- a/web/src/views/login.rs
+++ b/web/src/views/login.rs
@@ -1,0 +1,61 @@
+use dioxus::prelude::*;
+use crate::Route;
+
+#[component]
+pub fn Login() -> Element {
+    let mut username = use_signal(|| String::new());
+    let mut password = use_signal(|| String::new());
+    let navigator = use_navigator();
+
+    let on_login = move |_| {
+        let user = username().clone();
+        let pass = password().clone();
+        let nav = navigator.clone();
+        async move {
+            if api::login(user, pass).await.unwrap_or(false) {
+                nav.push(Route::Chat {});
+            }
+        }
+    };
+
+    let on_register = move |_| {
+        let user = username().clone();
+        let pass = password().clone();
+        async move {
+            api::register(user, pass).await.ok();
+        }
+    };
+
+    rsx! {
+        div { class: "flex flex-col space-y-2 p-4",
+            h1 { class: "text-xl font-bold", "Login" }
+            input {
+                class: "border p-1",
+                placeholder: "Username",
+                value: "{username}",
+                oninput: move |e| username.set(e.value()),
+            }
+            input {
+                class: "border p-1",
+                r#type: "password",
+                placeholder: "Password",
+                value: "{password}",
+                oninput: move |e| password.set(e.value()),
+            }
+            button {
+                class: "bg-blue-500 text-white p-1",
+                onclick: move |_| {
+                    spawn(on_login(()));
+                },
+                "Login"
+            }
+            button {
+                class: "bg-gray-700 text-white p-1",
+                onclick: move |_| {
+                    spawn(on_register(()));
+                },
+                "Register"
+            }
+        }
+    }
+}

--- a/web/src/views/mod.rs
+++ b/web/src/views/mod.rs
@@ -3,3 +3,6 @@ pub use chat::Chat;
 
 mod settings;
 pub use settings::Settings;
+
+mod login;
+pub use login::Login;


### PR DESCRIPTION
## Summary
- add in-memory user store and login/register server functions
- introduce Login page in web app and new route
- document basic authentication workflow

## Testing
- `dx fmt`
- `cargo check --workspace`
- `dx build --platform web --package web` *(fails: `Failed to find binary package to build`)*
- `dx build --platform desktop --package desktop` *(fails: no output due to heavy compilation)*

------
https://chatgpt.com/codex/tasks/task_e_6848632128b0832399b374afb8ad67bc