### PR TITLE
Add image generation support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,8 +51,10 @@ dependencies = [
 name = "api"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "dioxus",
  "once_cell",
+ "serde",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ members = [
 
 [workspace.dependencies]
 dioxus = { version = "0.6.0" }
+serde = { version = "1", features = ["derive"] }
+base64 = "0.22"
 
 # workspace
 ui = { path = "ui" }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2021"
 dioxus = { workspace = true, features = ["fullstack"] }
 once_cell = "1"
 tokio = { version = "1", features = ["sync"] }
+serde = { workspace = true }
+base64 = { workspace = true }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,11 +1,21 @@
 //! This crate contains all shared fullstack server functions.
 use dioxus::prelude::*;
 use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::RwLock;
+use base64::Engine;
+
+/// Represents a message in a conversation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ChatMessage {
+    Text(String),
+    /// Base64 encoded data uri of an image
+    Image(String),
+}
 
 /// Represents the messages for each conversation.
-type Conversations = Vec<Vec<String>>;
+type Conversations = Vec<Vec<ChatMessage>>;
 
 /// In memory list of chat messages.
 /// In memory list of conversations. Each conversation is a vector of chat messages.
@@ -35,7 +45,7 @@ pub async fn list_conversations() -> Result<Vec<usize>, ServerFnError> {
 
 /// Store a chat message in memory for a specific conversation.
 #[server(SendMessage)]
-pub async fn send_message(conv_id: usize, msg: String) -> Result<(), ServerFnError> {
+pub async fn send_message(conv_id: usize, msg: ChatMessage) -> Result<(), ServerFnError> {
     let mut history = CHAT_HISTORY.write().await;
     if let Some(conv) = history.get_mut(conv_id) {
         conv.push(msg);
@@ -45,7 +55,20 @@ pub async fn send_message(conv_id: usize, msg: String) -> Result<(), ServerFnErr
 
 /// Retrieve all chat messages for a specific conversation.
 #[server(GetMessages)]
-pub async fn get_messages(conv_id: usize) -> Result<Vec<String>, ServerFnError> {
+pub async fn get_messages(conv_id: usize) -> Result<Vec<ChatMessage>, ServerFnError> {
     let history = CHAT_HISTORY.read().await;
     Ok(history.get(conv_id).cloned().unwrap_or_default())
+}
+
+/// Generate an image from a prompt and return it as a data URI.
+#[server(GenerateImage)]
+pub async fn generate_image(prompt: String) -> Result<String, ServerFnError> {
+    let svg = format!(
+        "<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256'>\
+<rect width='100%' height='100%' fill='blue'/>\
+<text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='20' fill='white'>{}</text></svg>",
+        prompt
+    );
+    let encoded = base64::engine::general_purpose::STANDARD.encode(svg);
+    Ok(format!("data:image/svg+xml;base64,{}", encoded))
 }


### PR DESCRIPTION
## Summary
- extend message model to support image messages
- generate placeholder images server-side
- handle image messages in web chat view
- expose a DALL-E option in the model selector

## Testing
- `cargo check --workspace`
- `dx fmt`
- `dx build --platform web`
- `dx build --platform desktop` *(fails: `glib-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848649fc698832381e377cd0de38157