### PR TITLE
Add shareable chat links

### DIFF
--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -1,13 +1,15 @@
 use dioxus::prelude::*;
 
 mod views;
-use views::{Chat, Settings};
+use views::{Chat, ChatShare, Settings};
 
 #[derive(Debug, Clone, Routable, PartialEq)]
 #[rustfmt::skip]
 enum Route {
     #[route("/")]
     Chat {},
+    #[route("/chat/:id")]
+    ChatShare { id: usize },
     #[route("/settings")]
     Settings {},
 }

--- a/web/src/views/mod.rs
+++ b/web/src/views/mod.rs
@@ -1,5 +1,5 @@
 mod chat;
-pub use chat::Chat;
+pub use chat::{Chat, ChatShare};
 
 mod settings;
 pub use settings::Settings;


### PR DESCRIPTION
## Summary
- add `/chat/:id` route to open conversations directly
- implement `ChatBase` to handle optional conversation id
- add share link button in chat view

## Testing
- `cargo check --workspace`
- `dx build --platform web`
- `dx build --platform desktop` *(fails: `Failed to find binary package to build` / compile aborted)*

------
https://chatgpt.com/codex/tasks/task_e_684864bc63b4832395f4fb81c76002b3