### PR TITLE
Implement basic attachment support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,7 @@ version = "0.1.0"
 dependencies = [
  "dioxus",
  "once_cell",
+ "serde",
  "tokio",
 ]
 
@@ -2089,6 +2090,29 @@ dependencies = [
  "thiserror 1.0.69",
  "windows-sys 0.52.0",
  "x11-dl",
+]
+
+[[package]]
+name = "gloo-events"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c26fb45f7c385ba980f5fa87ac677e363949e065a083722697ef1b2cc91e41"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-file"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97563d71863fb2824b2e974e754a81d19c4a7ec47b09ced8a0e6656b6d54bd1f"
+dependencies = [
+ "futures-channel",
+ "gloo-events",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -5232,7 +5256,9 @@ name = "web"
 version = "0.1.0"
 dependencies = [
  "api",
+ "base64",
  "dioxus",
+ "gloo-file",
  "web-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ members = [
 
 [workspace.dependencies]
 dioxus = { version = "0.6.0" }
+serde = { version = "1", features = ["derive"] }
+base64 = "0.22"
 
 # workspace
 ui = { path = "ui" }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 dioxus = { workspace = true, features = ["fullstack"] }
 once_cell = "1"
 tokio = { version = "1", features = ["sync"] }
+serde = { workspace = true }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,15 +1,30 @@
 //! This crate contains all shared fullstack server functions.
 use dioxus::prelude::*;
+use serde::{Deserialize, Serialize};
 use once_cell::sync::Lazy;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-/// Represents the messages for each conversation.
-type Conversations = Vec<Vec<String>>;
+/// Attachment data sent with a chat message.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Attachment {
+    pub filename: String,
+    pub content_type: String,
+    pub data: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ChatMessage {
+    pub text: Option<String>,
+    pub attachment: Option<Attachment>,
+}
+
+type Conversations = Vec<Vec<ChatMessage>>;
 
 /// In memory list of chat messages.
 /// In memory list of conversations. Each conversation is a vector of chat messages.
-static CHAT_HISTORY: Lazy<Arc<RwLock<Conversations>>> = Lazy::new(|| Arc::new(RwLock::new(vec![Vec::new()])));
+static CHAT_HISTORY: Lazy<Arc<RwLock<Conversations>>> =
+    Lazy::new(|| Arc::new(RwLock::new(vec![Vec::new()])));
 
 /// Echo the user input on the server.
 #[server(Echo)]
@@ -35,7 +50,7 @@ pub async fn list_conversations() -> Result<Vec<usize>, ServerFnError> {
 
 /// Store a chat message in memory for a specific conversation.
 #[server(SendMessage)]
-pub async fn send_message(conv_id: usize, msg: String) -> Result<(), ServerFnError> {
+pub async fn send_message(conv_id: usize, msg: ChatMessage) -> Result<(), ServerFnError> {
     let mut history = CHAT_HISTORY.write().await;
     if let Some(conv) = history.get_mut(conv_id) {
         conv.push(msg);
@@ -45,7 +60,7 @@ pub async fn send_message(conv_id: usize, msg: String) -> Result<(), ServerFnErr
 
 /// Retrieve all chat messages for a specific conversation.
 #[server(GetMessages)]
-pub async fn get_messages(conv_id: usize) -> Result<Vec<String>, ServerFnError> {
+pub async fn get_messages(conv_id: usize) -> Result<Vec<ChatMessage>, ServerFnError> {
     let history = CHAT_HISTORY.read().await;
     Ok(history.get(conv_id).cloned().unwrap_or_default())
 }

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 dioxus = { workspace = true, features = ["router"] }
 api = { workspace = true }
 web-sys = { version = "0.3", features = ["Window", "MediaQueryList"] }
+gloo-file = { version = "0.3", features = ["futures"] }
+base64 = { workspace = true }
 
 [features]
 default = []


### PR DESCRIPTION
## Summary
- enable serde and base64 in workspace
- add attachment structs in API
- support sending and receiving attachments in web chat
- handle file upload and display images or PDFs

## Testing
- `cargo check --workspace`
- `dx build --platform web --package web` *(fails: FileEngine trait bounds, missing features)*
- `dx build --platform desktop --package desktop` *(fails: glib-2.0 missing)*


------
https://chatgpt.com/codex/tasks/task_e_68486346c65c8323be72819865a6f59f